### PR TITLE
DDCE-6670: Kosovo country added in both English and Welsh.

### DIFF
--- a/conf/location-autocomplete-canonical-list.json
+++ b/conf/location-autocomplete-canonical-list.json
@@ -1,5 +1,9 @@
 [
   [
+    "Kosovo",
+    "country:XK"
+  ],
+  [
     "Andorra",
     "country:AD"
   ],

--- a/conf/location-canonical-list-nonUK.json
+++ b/conf/location-canonical-list-nonUK.json
@@ -1,5 +1,9 @@
 [
   [
+    "Kosovo",
+    "country:XK"
+  ],
+  [
     "Andorra",
     "country:AD"
   ],


### PR DESCRIPTION
DDCE-6670: Kosovo country added in both English and Welsh. #91
